### PR TITLE
Implement DiffEvents for an event/stream-based API

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,16 +59,31 @@ diff-table \
   "type_changes": {},
   "rows_added": 1,
   "rows_deleted": 1,
-  "rows_changed": 1,
+  "rows_changed": 2,
   "row_diffs": [
     {
       "key": {
         "id": "1"
       },
       "changes": {
+        "city": {
+          "old": null,
+          "new": "Trenton"
+        },
         "color": {
           "old": "Blue",
           "new": "Teal"
+        }
+      }
+    },
+    {
+      "key": {
+        "id": "3"
+      },
+      "changes": {
+        "city": {
+          "old": null,
+          "new": "Philadelphia"
         }
       }
     }
@@ -102,7 +117,7 @@ diff-table \
 
 The output is a newline-delimited set of JSON-encoded events. Column-based changes will always come first. The `type` field denotes the type of event which can be switched on during consumption.
 
-```jsons
+```json
 {
   "type": "column-added",
   "column": "city"
@@ -114,6 +129,10 @@ The output is a newline-delimited set of JSON-encoded events. Column-based chang
     "id": "1"
   },
   "changes": {
+    "city": {
+      "old": null,
+      "new": "Trenton"
+    },
     "color": {
       "old": "Blue",
       "new": "Teal"
@@ -125,6 +144,19 @@ The output is a newline-delimited set of JSON-encoded events. Column-based chang
   "offset": 2,
   "key": {
     "id": "2"
+  }
+}
+{
+  "type": "row-changed",
+  "offset": 3,
+  "key": {
+    "id": "3"
+  },
+  "changes": {
+    "city": {
+      "old": null,
+      "new": "Philadelphia"
+    }
   }
 }
 {

--- a/README.md
+++ b/README.md
@@ -14,48 +14,138 @@ go get -u github.com/chop-dbhi/diff-table/cmd/diff-table
 
 ## Usage
 
+The minimum requirement is to specify two tables (CSV or relational) and specify the key columns. For example, using the provided example data in the repository, the command would look like this.
+
 ```
 diff-table \
-  -db postgres://localhost:5432/postgres \
-  -table1 data_v1 \
-  -table2 data_v2 \
+  -csv1 example/file1.csv \
+  -csv2 example/file2.csv \
   -key id
 ```
 
-The output is a JSON encoded value which various information about the table differences. If `-diff` is supplied, `row_diffs`, `new_rows`, and `deleted_rows` are included as well. Note, this may significantly increase memory usage if the tables are vastly different.
+The default output is a JSON encoded object with a summary of the differences, including column and row changes.
 
-```
+```json
 {
-  "total_rows": 2055856,
-  "columns_added": [],
+  "total_rows": 4,
+  "columns_added": [
+    "city"
+  ],
   "columns_dropped": [],
   "type_changes": {},
   "rows_added": 1,
-  "rows_deleted": 0,
+  "rows_deleted": 1,
+  "rows_changed": 1
+}
+```
+
+Adding the `-diff` option in the command will result in row-level changes in the output.
+
+```
+diff-table \
+  -csv1 example/file1.csv \
+  -csv2 example/file2.csv \
+  -key id \
+  -diff
+```
+
+```json
+{
+  "total_rows": 4,
+  "columns_added": [
+    "city"
+  ],
+  "columns_dropped": [],
+  "type_changes": {},
+  "rows_added": 1,
+  "rows_deleted": 1,
   "rows_changed": 1,
   "row_diffs": [
     {
       "key": {
-        "id": 2009
+        "id": "1"
       },
       "changes": {
-        "val": {
-          "old": 0.7576323747634888,
-          "new": 1.323199987411499
+        "color": {
+          "old": "Blue",
+          "new": "Teal"
         }
       }
     }
   ],
   "new_rows": [
     {
-      "id": 2010,
-      "val": 1.53921932383223
+      "city": "Allentown",
+      "color": "Black",
+      "gender": "Male",
+      "id": "4",
+      "name": "Neal"
+    }
+  ],
+  "deleted_rows": [
+    {
+      "id": "2"
     }
   ]
 }
 ```
 
+This type of output is convenient for summary usage, however in some use cases a set of events may be more useful. Using the `-events` option will result in the changes being streamed as they are discovered rather than aggregating everything up into a single output object.
+
+```
+diff-table \
+  -csv1 example/file1.csv \
+  -csv2 example/file2.csv \
+  -key id \
+  -events
+```
+
+The output is a newline-delimited set of JSON-encoded events. Column-based changes will always come first. The `type` field denotes the type of event which can be switched on during consumption.
+
+```jsons
+{
+  "type": "column-added",
+  "column": "city"
+}
+{
+  "type": "row-changed",
+  "offset": 1,
+  "key": {
+    "id": "1"
+  },
+  "changes": {
+    "color": {
+      "old": "Blue",
+      "new": "Teal"
+    }
+  }
+}
+{
+  "type": "row-removed",
+  "offset": 2,
+  "key": {
+    "id": "2"
+  }
+}
+{
+  "type": "row-added",
+  "offset": 4,
+  "key": {
+    "id": "4"
+  },
+  "data": {
+    "city": "Allentown",
+    "color": "Black",
+    "gender": "Male",
+    "id": "4",
+    "name": "Neal"
+  }
+}
+```
+
 ## Examples
+
+Below are examples of how tables can be specified including SQL-based tables and CSV files (with sorted or unsorted rows).
 
 ### Tables in the same database
 

--- a/cmd/diff-table/main.go
+++ b/cmd/diff-table/main.go
@@ -15,7 +15,8 @@ import (
 
 func main() {
 	var (
-		keyList  string
+		key1List string
+		key2List string
 		diffRows bool
 
 		csv1      string
@@ -37,7 +38,8 @@ func main() {
 		events bool
 	)
 
-	flag.StringVar(&keyList, "key", "", "Required comma-separate list of columns.")
+	flag.StringVar(&key1List, "key", "", "Comma-separate list of columns in table 1.")
+	flag.StringVar(&key2List, "key2", "", "Comma-separate list of columns in table 2. Default to key option.")
 	flag.BoolVar(&diffRows, "diff", false, "Diff row values and output changes.")
 
 	flag.StringVar(&csv1, "csv1", "", "Path to CSV file.")
@@ -60,12 +62,23 @@ func main() {
 
 	flag.Parse()
 
-	if keyList == "" {
-		log.Print("key list required")
+	if key1List == "" {
+		log.Fatal("key required")
 		return
 	}
 
-	key := strings.Split(keyList, ",")
+	key1 := strings.Split(key1List, ",")
+	var key2 []string
+
+	if key2List == "" {
+		key2 = key1
+	} else {
+		key2 = strings.Split(key2List, ",")
+	}
+
+	if len(key1) != len(key2) {
+		log.Fatal("keys must be the same length")
+	}
 
 	if url2 == "" {
 		url2 = url1
@@ -82,12 +95,12 @@ func main() {
 	)
 
 	if csv1 != "" && url1 != "" {
-		log.Print("can't both a csv and db source defined")
+		log.Fatal("can't both a csv and db source defined")
 		return
 	}
 
 	if csv2 != "" && url2 != "" {
-		log.Print("can't both a csv and db target defined")
+		log.Fatal("can't both a csv and db target defined")
 		return
 	}
 
@@ -102,13 +115,13 @@ func main() {
 		cr1 := difftable.NewCSVReader(f1, rune(csv1delim[0]))
 
 		if csv1sort {
-			t1, err = difftable.UnsortedCSVTable(cr1, key)
+			t1, err = difftable.UnsortedCSVTable(cr1, key1)
 			if err != nil {
 				log.Printf("csv1 table: %s", err)
 				return
 			}
 		} else {
-			t1, err = difftable.CSVTable(cr1, key)
+			t1, err = difftable.CSVTable(cr1, key1)
 			if err != nil {
 				log.Printf("csv1 table: %s", err)
 				return
@@ -127,13 +140,13 @@ func main() {
 		cr2 := difftable.NewCSVReader(f2, rune(csv2delim[0]))
 
 		if csv2sort {
-			t2, err = difftable.UnsortedCSVTable(cr2, key)
+			t2, err = difftable.UnsortedCSVTable(cr2, key2)
 			if err != nil {
 				log.Printf("csv2 table: %s", err)
 				return
 			}
 		} else {
-			t2, err = difftable.CSVTable(cr2, key)
+			t2, err = difftable.CSVTable(cr2, key2)
 			if err != nil {
 				log.Printf("csv2 table: %s", err)
 				return
@@ -152,14 +165,15 @@ func main() {
 	}
 
 	if db1 != nil {
-		rows1, err := runQuery(db1, schema1, table1, key)
+		rows1, err := runQuery(db1, schema1, table1, key1)
 		if err != nil {
+			db1.Close()
 			log.Printf("db1 query: %s", err)
 			return
 		}
 		defer rows1.Close()
 
-		t1, err = difftable.SQLTable(rows1, key)
+		t1, err = difftable.SQLTable(rows1, key1)
 		if err != nil {
 			log.Printf("db1 table: %s", err)
 			return
@@ -176,14 +190,15 @@ func main() {
 	}
 
 	if db2 != nil {
-		rows2, err := runQuery(db2, schema2, table2, key)
+		rows2, err := runQuery(db2, schema2, table2, key2)
 		if err != nil {
+			db2.Close()
 			log.Printf("db2 query: %s", err)
 			return
 		}
 		defer rows2.Close()
 
-		t2, err = difftable.SQLTable(rows2, key)
+		t2, err = difftable.SQLTable(rows2, key2)
 		if err != nil {
 			log.Printf("db2 table: %s", err)
 			return

--- a/csv_test.go
+++ b/csv_test.go
@@ -1,0 +1,178 @@
+package difftable
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+var (
+	csvTable1 = `id,name,gender,color
+1,John,Male,Blue
+2,Pam,Female,Red
+3,Sam,Female,Yellow
+`
+
+	csvTable2 = `id,name,gender,color,city
+1,John,Male,Teal,Trenton
+3,Sam,Female,Yellow,Philadelphia
+4,Neal,Male,Black,Allentown
+`
+
+	csvTableDiff = &TableDiff{
+		TotalRows:   4,
+		ColsAdded:   []string{"city"},
+		RowsAdded:   1,
+		RowsDeleted: 1,
+		RowsChanged: 1,
+		NewRows: []map[string]interface{}{
+			{
+				"city":   "Alletown",
+				"color":  "Black",
+				"gender": "Male",
+				"id":     "4",
+				"name":   "Neal",
+			},
+		},
+		DeletedRows: []map[string]interface{}{
+			{
+				"id": "2",
+			},
+		},
+		RowDiffs: []*RowDiff{
+			{
+				Key: map[string]interface{}{
+					"id": "1",
+				},
+				Changes: map[string]*ValueChange{
+					"color": &ValueChange{
+						Old: "Blue",
+						New: "Teal",
+					},
+				},
+			},
+		},
+	}
+
+	csvDiffEvents = []*Event{
+		{
+			Type:   EventColumnAdded,
+			Column: "city",
+		},
+		{
+			Type:   EventRowChanged,
+			Offset: 1,
+			Key: map[string]interface{}{
+				"id": "1",
+			},
+			Changes: map[string]*ValueChange{
+				"color": &ValueChange{
+					Old: "Blue",
+					New: "Teal",
+				},
+			},
+		},
+		{
+			Type:   EventRowRemoved,
+			Offset: 2,
+			Key: map[string]interface{}{
+				"id": "2",
+			},
+		},
+		{
+			Type:   EventRowAdded,
+			Offset: 4,
+			Key: map[string]interface{}{
+				"id": "4",
+			},
+			Data: map[string]interface{}{
+				"city":   "Alletown",
+				"color":  "Black",
+				"gender": "Male",
+				"id":     "4",
+				"name":   "Neal",
+			},
+		},
+	}
+)
+
+func TestCsvTable(t *testing.T) {
+	r1 := bytes.NewBufferString(csvTable1)
+	c1 := NewCSVReader(r1, ',')
+
+	r2 := bytes.NewBufferString(csvTable2)
+	c2 := NewCSVReader(r2, ',')
+
+	key := []string{"id"}
+
+	t1, err := CSVTable(c1, key)
+	t2, err := CSVTable(c2, key)
+
+	diff, err := Diff(t1, t2, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if reflect.DeepEqual(diff, csvTableDiff) {
+		t.Errorf("diff doesn't match. expected:\n%sgot:\n%s", csvTableDiff, diff)
+	}
+
+	var events []*Event
+	err = DiffEvents(t1, t2, func(e *Event) {
+		events = append(events, e)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if reflect.DeepEqual(events, csvDiffEvents) {
+		t.Errorf("diff events don't match. expected:\n%sgot:\n%s", csvDiffEvents, events)
+	}
+}
+
+var (
+	unsortedCsvTable1 = `id,name,gender,color
+2,Pam,Female,Red
+3,Sam,Female,Yellow
+1,John,Male,Blue
+`
+	unsortedCsvTable2 = `id,name,gender,color,city
+4,Neal,Male,Black,Allentown
+1,John,Male,Teal,Trenton
+3,Sam,Female,Yellow,Philadelphia
+`
+)
+
+func TestUnsortedCsvTable(t *testing.T) {
+	r1 := bytes.NewBufferString(unsortedCsvTable1)
+	c1 := NewCSVReader(r1, ',')
+
+	r2 := bytes.NewBufferString(unsortedCsvTable2)
+	c2 := NewCSVReader(r2, ',')
+
+	key := []string{"id"}
+
+	t1, err := UnsortedCSVTable(c1, key)
+	t2, err := UnsortedCSVTable(c2, key)
+
+	diff, err := Diff(t1, t2, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if reflect.DeepEqual(diff, csvTableDiff) {
+		t.Errorf("diff doesn't match. expected:\n%sgot:\n%s", csvTableDiff, diff)
+	}
+
+	var events []*Event
+	err = DiffEvents(t1, t2, func(e *Event) {
+		events = append(events, e)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if reflect.DeepEqual(events, csvDiffEvents) {
+		t.Errorf("diff events don't match. expected:\n%sgot:\n%s", csvDiffEvents, events)
+	}
+}

--- a/example/file1.csv
+++ b/example/file1.csv
@@ -1,0 +1,4 @@
+id,name,gender,color
+1,John,Male,Blue
+2,Pam,Female,Red
+3,Sam,Female,Yellow

--- a/example/file2.csv
+++ b/example/file2.csv
@@ -1,0 +1,4 @@
+id,name,gender,color,city
+1,John,Male,Teal,Trenton
+3,Sam,Female,Yellow,Philadelphia
+4,Neal,Male,Black,Allentown

--- a/table.go
+++ b/table.go
@@ -51,214 +51,24 @@ type RowDiff struct {
 	Changes map[string]*ValueChange `json:"changes"`
 }
 
-// Diff takes two tables and diffs them. If diffRows is true, value-level changes
-// will be reported as well.
-func Diff(t1, t2 Table, diffRows bool) (*TableDiff, error) {
-	key1 := t1.Key()
-	key2 := t2.Key()
+const (
+	EventColumnAdded   = "column-added"
+	EventColumnChanged = "column-changed"
+	EventColumnRemoved = "column-removed"
+	EventRowAdded      = "row-added"
+	EventRowChanged    = "row-changed"
+	EventRowRemoved    = "row-removed"
+)
 
-	if len(key1) == 0 || len(key2) == 0 {
-		return nil, errors.New("a key must be provided")
-	}
-
-	if len(key1) != len(key2) {
-		return nil, errors.New("keys are different lengths")
-	}
-
-	diff := TableDiff{
-		ColsAdded:   make([]string, 0),
-		ColsDropped: make([]string, 0),
-		TypeChanges: make(map[string]*TypeChange),
-	}
-
-	cols1 := t1.Cols()
-	cols2 := t2.Cols()
-
-	// For lookup.
-	keyMap := make(map[string]struct{}, len(key1))
-	for _, c := range key1 {
-		keyMap[c] = struct{}{}
-	}
-
-	// Columns to check when comparing rows.
-	var cmpcols []string
-
-	for c, ty1 := range cols1 {
-		// Both exist check for type changes.
-		if ty2, ok := cols2[c]; ok {
-			if ty1 != ty2 {
-				diff.TypeChanges[c] = &TypeChange{
-					Old: ty1,
-					New: ty2,
-				}
-				continue
-			}
-
-			// Add non-key column for row comparison.
-			if _, ok := keyMap[c]; !ok {
-				cmpcols = append(cmpcols, c)
-			}
-			continue
-		}
-
-		// Column doesn't exist in t2, thus is was dropped.
-		diff.ColsDropped = append(diff.ColsDropped, c)
-	}
-
-	// Check for new columns.
-	for c := range cols2 {
-		if _, ok := cols1[c]; !ok {
-			diff.ColsAdded = append(diff.ColsAdded, c)
-		}
-	}
-
-	var (
-		// Flags for whether to call next for the respective table.
-		n1 = true
-		n2 = true
-
-		// Key values as bytes for determine next in sequence.
-		k1 = make([][]byte, len(key1))
-		k2 = make([][]byte, len(key2))
-
-		// Next call was ok.
-		ok1 bool
-		ok2 bool
-
-		err error
-	)
-
-	// Single references.
-	var r1, r2 Row
-
-	for {
-		// Advance to rows.
-		if n1 {
-			n1 = false
-			ok1, err = t1.Next()
-			if err != nil {
-				return nil, err
-			}
-
-			r1 = t1.Row()
-
-			// Set key.
-			if ok1 {
-				for i, c := range key1 {
-					k1[i] = r1.Bytes(c)
-				}
-			}
-		}
-
-		if n2 {
-			n2 = false
-			ok2, err = t2.Next()
-			if err != nil {
-				return nil, err
-			}
-
-			r2 = t2.Row()
-
-			// Set key.
-			if ok2 {
-				for i, c := range key2 {
-					k2[i] = r2.Bytes(c)
-				}
-			}
-		}
-
-		// Done.
-		if !ok1 && !ok2 {
-			break
-		}
-
-		diff.TotalRows++
-
-		// No more rows in old table.
-		if !ok1 {
-			diff.RowsAdded++
-			n2 = true
-			if diffRows {
-				diff.NewRows = append(diff.NewRows, newValueMap(r2, cols2))
-			}
-			continue
-		}
-
-		// No more rows in new table.
-		if !ok2 {
-			diff.RowsDeleted++
-			n1 = true
-
-			if diffRows {
-				diff.DeletedRows = append(diff.DeletedRows, newKeyMap(r1, key1))
-			}
-			continue
-		}
-
-		// Check if keys match.
-		p := compareRows(k1, k2)
-
-		// Row seen in old table, but not new table, thus it has been deleted.
-		if p == -1 {
-			diff.RowsDeleted++
-			n1 = true
-
-			if diffRows {
-				diff.DeletedRows = append(diff.DeletedRows, newKeyMap(r1, key1))
-			}
-			continue
-		}
-
-		// Row seen in new table, but not old table, thus it has been added.
-		if p == 1 {
-			diff.RowsAdded++
-			n2 = true
-
-			if diffRows {
-				diff.NewRows = append(diff.NewRows, newValueMap(r2, cols2))
-			}
-			continue
-		}
-
-		if len(cmpcols) > 0 {
-			var rd *RowDiff
-
-			// Row keys match, compare column values.
-			for _, c := range cmpcols {
-				if !bytes.Equal(r1.Bytes(c), r2.Bytes(c)) {
-					// Stop on first difference.
-					if !diffRows {
-						diff.RowsChanged++
-						break
-					}
-
-					// Initialze row diff.
-					if rd == nil {
-						rd = &RowDiff{
-							Key:     newKeyMap(r1, key1),
-							Changes: make(map[string]*ValueChange),
-						}
-					}
-
-					rd.Changes[c] = &ValueChange{
-						Old: r1.Value(c),
-						New: r2.Value(c),
-					}
-				}
-			}
-
-			if rd != nil {
-				diff.RowsChanged++
-				diff.RowDiffs = append(diff.RowDiffs, rd)
-			}
-		}
-
-		// Advance both.
-		n1 = true
-		n2 = true
-	}
-
-	return &diff, nil
+type Event struct {
+	Type    string                  `json:"type"`
+	Offset  int64                   `json:"offset,omitempty"`
+	Column  string                  `json:"column,omitempty"`
+	OldType string                  `json:"old_type,omitempty"`
+	NewType string                  `json:"new_type,omitempty"`
+	Key     map[string]interface{}  `json:"key,omitempty"`
+	Data    map[string]interface{}  `json:"data,omitempty"`
+	Changes map[string]*ValueChange `json:"changes,omitempty"`
 }
 
 func compareRows(r1, r2 [][]byte) int {
@@ -286,4 +96,277 @@ func newKeyMap(r Row, cols []string) map[string]interface{} {
 	}
 
 	return c
+
+}
+
+func DiffEvents(t1, t2 Table, h func(e *Event)) error {
+	key1 := t1.Key()
+	key2 := t2.Key()
+
+	if len(key1) == 0 || len(key2) == 0 {
+		return errors.New("a key must be provided")
+	}
+
+	if len(key1) != len(key2) {
+		return errors.New("keys are different lengths")
+	}
+
+	cols1 := t1.Cols()
+	cols2 := t2.Cols()
+
+	// For lookup.
+	keyMap := make(map[string]struct{}, len(key1))
+	for _, c := range key1 {
+		keyMap[c] = struct{}{}
+	}
+
+	// Columns to check when comparing rows.
+	var cmpcols []string
+
+	for c, ty1 := range cols1 {
+		// Both exist check for type changes.
+		if ty2, ok := cols2[c]; ok {
+			if ty1 != ty2 {
+				h(&Event{
+					Type:    EventColumnChanged,
+					Column:  c,
+					OldType: ty1,
+					NewType: ty2,
+				})
+				continue
+			}
+
+			// Add non-key column for row comparison.
+			if _, ok := keyMap[c]; !ok {
+				cmpcols = append(cmpcols, c)
+			}
+			continue
+		}
+
+		// Column doesn't exist in t2, thus is was dropped.
+		h(&Event{
+			Type:   EventColumnRemoved,
+			Column: c,
+		})
+	}
+
+	// Check for new columns.
+	for c := range cols2 {
+		if _, ok := cols1[c]; !ok {
+			h(&Event{
+				Type:   EventColumnAdded,
+				Column: c,
+			})
+		}
+	}
+
+	var (
+		// Flags for whether to call next for the respective table.
+		n1 = true
+		n2 = true
+
+		// Key values as bytes for determine next in sequence.
+		k1 = make([][]byte, len(key1))
+		k2 = make([][]byte, len(key2))
+
+		// Next call was ok.
+		ok1 bool
+		ok2 bool
+
+		err error
+	)
+
+	// Single references.
+	var r1, r2 Row
+	var offset int64
+
+	for {
+		offset++
+
+		// Advance to rows.
+		if n1 {
+			n1 = false
+			ok1, err = t1.Next()
+			if err != nil {
+				return err
+			}
+
+			r1 = t1.Row()
+
+			// Set key.
+			if ok1 {
+				for i, c := range key1 {
+					k1[i] = r1.Bytes(c)
+				}
+			}
+		}
+
+		if n2 {
+			n2 = false
+			ok2, err = t2.Next()
+			if err != nil {
+				return err
+			}
+
+			r2 = t2.Row()
+
+			// Set key.
+			if ok2 {
+				for i, c := range key2 {
+					k2[i] = r2.Bytes(c)
+				}
+			}
+		}
+
+		// Done.
+		if !ok1 && !ok2 {
+			break
+		}
+
+		// No more rows in old table.
+		if !ok1 {
+			n2 = true
+			h(&Event{
+				Type:   EventRowAdded,
+				Offset: offset,
+				Key:    newKeyMap(r2, key2),
+				Data:   newValueMap(r2, cols2),
+			})
+
+			continue
+		}
+
+		// No more rows in new table.
+		if !ok2 {
+			n1 = true
+
+			h(&Event{
+				Type:   EventRowRemoved,
+				Offset: offset,
+				Key:    newKeyMap(r1, key1),
+			})
+			continue
+		}
+
+		// Check if keys match.
+		p := compareRows(k1, k2)
+
+		// Row seen in old table, but not new table, thus it has been deleted.
+		if p == -1 {
+			n1 = true
+
+			h(&Event{
+				Type:   EventRowRemoved,
+				Offset: offset,
+				Key:    newKeyMap(r1, key1),
+			})
+			continue
+		}
+
+		// Row seen in new table, but not old table, thus it has been added.
+		if p == 1 {
+			n2 = true
+
+			h(&Event{
+				Type:   EventRowAdded,
+				Offset: offset,
+				Key:    newKeyMap(r2, key2),
+				Data:   newValueMap(r2, cols2),
+			})
+			continue
+		}
+
+		if len(cmpcols) > 0 {
+			var rd *RowDiff
+
+			// Row keys match, compare column values.
+			for _, c := range cmpcols {
+				if !bytes.Equal(r1.Bytes(c), r2.Bytes(c)) {
+					// Initialze row diff.
+					if rd == nil {
+						rd = &RowDiff{
+							Key:     newKeyMap(r1, key1),
+							Changes: make(map[string]*ValueChange),
+						}
+					}
+
+					rd.Changes[c] = &ValueChange{
+						Old: r1.Value(c),
+						New: r2.Value(c),
+					}
+				}
+			}
+
+			if rd != nil {
+				h(&Event{
+					Type:    EventRowChanged,
+					Offset:  offset,
+					Key:     rd.Key,
+					Changes: rd.Changes,
+				})
+
+			}
+		}
+
+		// Advance both.
+		n1 = true
+		n2 = true
+	}
+
+	return nil
+}
+
+// Diff takes two tables and diffs them. If diffRows is true, value-level changes
+// will be reported as well.
+func Diff(t1, t2 Table, diffRows bool) (*TableDiff, error) {
+	diff := TableDiff{
+		ColsAdded:   make([]string, 0),
+		ColsDropped: make([]string, 0),
+		TypeChanges: make(map[string]*TypeChange),
+	}
+
+	err := DiffEvents(t1, t2, func(e *Event) {
+		diff.TotalRows = e.Offset
+
+		switch e.Type {
+		case EventColumnAdded:
+			diff.ColsAdded = append(diff.ColsAdded, e.Column)
+
+		case EventColumnRemoved:
+			diff.ColsDropped = append(diff.ColsDropped, e.Column)
+
+		case EventColumnChanged:
+			diff.TypeChanges[e.Column] = &TypeChange{
+				Old: e.OldType,
+				New: e.NewType,
+			}
+
+		case EventRowAdded:
+			diff.RowsAdded++
+			if diffRows {
+				diff.NewRows = append(diff.NewRows, e.Data)
+			}
+
+		case EventRowRemoved:
+			diff.RowsDeleted++
+			if diffRows {
+				diff.DeletedRows = append(diff.DeletedRows, e.Key)
+			}
+
+		case EventRowChanged:
+			diff.RowsChanged++
+			if diffRows {
+				diff.RowDiffs = append(diff.RowDiffs, &RowDiff{
+					Key:     e.Key,
+					Changes: e.Changes,
+				})
+			}
+		}
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &diff, nil
 }

--- a/table.go
+++ b/table.go
@@ -319,10 +319,14 @@ func DiffEvents(t1, t2 Table, h func(e *Event)) error {
 // Diff takes two tables and diffs them. If diffRows is true, value-level changes
 // will be reported as well.
 func Diff(t1, t2 Table, diffRows bool) (*TableDiff, error) {
+	// Initial empty values for proper JSON encoding..
 	diff := TableDiff{
 		ColsAdded:   make([]string, 0),
 		ColsDropped: make([]string, 0),
 		TypeChanges: make(map[string]*TypeChange),
+		RowDiffs:    make([]*RowDiff, 0),
+		NewRows:     make([]map[string]interface{}, 0),
+		DeletedRows: make([]map[string]interface{}, 0),
 	}
 
 	err := DiffEvents(t1, t2, func(e *Event) {

--- a/table.go
+++ b/table.go
@@ -115,9 +115,9 @@ func DiffEvents(t1, t2 Table, h func(e *Event)) error {
 	cols1 := t1.Cols()
 	cols2 := t2.Cols()
 
-	// Build lookups for key columns.
 	// Validate both tables have the key columns.
-	key1Map := make(map[string]struct{}, len(key1))
+	// Build lookups key columns.
+	key1Map := make(map[string]struct{}, len(key2))
 	for _, c := range key1 {
 		if _, ok := cols1[c]; !ok {
 			return fmt.Errorf("table 1 does not have key column `%s`", c)
@@ -141,15 +141,12 @@ func DiffEvents(t1, t2 Table, h func(e *Event)) error {
 	)
 
 	for c, ty1 := range cols1 {
-		// Ignore key columns.
-		if _, ok := key1Map[c]; ok {
-			continue
-		}
-
 		// Both exist check for type changes.
 		if ty2, ok := cols2[c]; ok {
-			// Not a key column in 2. Add as shared column.
-			if _, ok := key2Map[c]; !ok {
+			// Not a shared key column. Mark for comparison.
+			_, ok1 := key1Map[c]
+			_, ok2 := key2Map[c]
+			if !(ok1 && ok2) {
 				cmpCols = append(cmpCols, c)
 			}
 
@@ -177,11 +174,6 @@ func DiffEvents(t1, t2 Table, h func(e *Event)) error {
 
 	// Check for new columns.
 	for c := range cols2 {
-		// Ignore key columns.
-		if _, ok := key2Map[c]; ok {
-			continue
-		}
-
 		// New column.
 		if _, ok := cols1[c]; !ok {
 			newCols = append(newCols, c)


### PR DESCRIPTION
Internally, this is now the default used by the Diff function to
build the "stateful" TableDiff output. The `-events` option has been
added to the CLI to stream events as JSON as the diff is executing.

The README has been updated to reflect this change with an example.

Signed-off-by: Byron Ruth <b@devel.io>